### PR TITLE
Remove `oldtime` from `chono` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.19", default-features = false, features = ["serde"] }
 http = "0.2.8"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"


### PR DESCRIPTION
Fixes #18

Only feature serde is required to build and test.

Sometimes feature clock is required but this gives all the req'd features.

Addresses several security advisories that are flagged on the old time.