### PR TITLE
Implement string deserializer for context, use `derive_builder` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ http = "0.2.8"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 serde_tuple = "0.5.0"
+derive_builder = "0.12.0"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn serialize_actor() {
         let actual = Document::new(
-            ContextBuilder::new().build(),
+            ContextBuilder::new().build().unwrap(),
             ActorBuilder::new(String::from("Person"))
                 .id("https://example.com/person/1234"
                     .parse::<http::Uri>()
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn serialize_note() {
         let actual = Document::new(
-            ContextBuilder::new().build(),
+            ContextBuilder::new().build().unwrap(),
             Note::new(String::from("Name"), String::from("Content")),
         );
         let expected = r#"{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod extended;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Result;
 
+extern crate derive_builder;
+
 pub trait Serde
 where
     Self: Serialize + DeserializeOwned,
@@ -404,7 +406,7 @@ mod tests {
     #[test]
     fn minimal_activity_3_1() {
         let actual = Document::new(
-            ContextBuilder::new().build(),
+            ContextBuilder::new().build().unwrap(),
             ActivityBuilder::new(
                 String::from("Create"),
                 String::from("Martin created an image"),
@@ -440,7 +442,7 @@ mod tests {
     #[test]
     fn basic_activity_with_additional_detail_3_2() {
         let actual = Document::new(
-            ContextBuilder::new().build(),
+            ContextBuilder::new().build().unwrap(),
             ActivityBuilder::new(
                 String::from("Add"),
                 String::from("Martin added an article to his blog"),
@@ -524,7 +526,7 @@ mod tests {
     #[test]
     fn object_4_1_7() {
         let actual = Document::new(
-            ContextBuilder::new().build(),
+            ContextBuilder::new().build().unwrap(),
             ObjectBuilder::new()
                 .id("http://example.org/foo".parse::<http::Uri>().unwrap())
                 .object_type(String::from("Note"))


### PR DESCRIPTION
This PR does two things;

### let's use `derive_builder`

It _significantly_ reduces boilerplate. I've added it for `Context`, but we can use it for other structs.

### custom deserializer for `Context`

This allows us have the `String`-type `Context` and points the way to the array, and other custom deserializers.

@dmah42 I'm probably going to continue this strategy this weekend