### PR TITLE
Replace almost all raw strings with the `json!` macro

### DIFF
--- a/src/core/activity.rs
+++ b/src/core/activity.rs
@@ -1,7 +1,7 @@
-use serde::{ Deserialize, Serialize };
+use crate::core::actor::{Actor, ActorBuilder};
+use crate::core::object::{Object, ObjectBuilder};
 use derive_builder::Builder;
-use crate::core::object::{ Object, ObjectBuilder };
-use crate::core::actor::{ Actor, ActorBuilder };
+use serde::{Deserialize, Serialize};
 
 ///////////////////////////////
 // Activity
@@ -39,31 +39,34 @@ pub struct Activity {
 }
 
 impl ActivityBuilder {
-
     // TODO: macro
     pub fn with_base<F>(&mut self, build_fn: F) -> &mut Self
-        where F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder
+    where
+        F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder,
     {
         let mut base_builder = ObjectBuilder::default();
         self.base(build_fn(&mut base_builder).build().unwrap())
     }
 
     pub fn with_object<F>(&mut self, build_fn: F) -> &mut Self
-        where F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder
+    where
+        F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder,
     {
         let mut base_builder = ObjectBuilder::default();
         self.object(Some(build_fn(&mut base_builder).build().unwrap()))
     }
 
     pub fn with_actor<F>(&mut self, build_fn: F) -> &mut Self
-        where F: FnOnce(&mut ActorBuilder) -> &mut ActorBuilder
+    where
+        F: FnOnce(&mut ActorBuilder) -> &mut ActorBuilder,
     {
         let mut base_builder = ActorBuilder::default();
         self.actor(Some(build_fn(&mut base_builder).build().unwrap()))
     }
 
     pub fn with_target<F>(&mut self, build_fn: F) -> &mut Self
-        where F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder
+    where
+        F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder,
     {
         let mut base_builder = ObjectBuilder::default();
         self.target(Some(build_fn(&mut base_builder).build().unwrap()))
@@ -74,37 +77,40 @@ impl ActivityBuilder {
     pub fn intransitive_activity(object_type: String) -> Self {
         let obj = ObjectBuilder::default()
             .object_type(Some(object_type))
-            .build().unwrap();
-        ActivityBuilder::default()
-            .base(obj)
-            .object(None).to_owned()
+            .build()
+            .unwrap();
+        ActivityBuilder::default().base(obj).object(None).to_owned()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{ContextBuilder, Document};
     use pretty_assertions::assert_eq;
-    use crate::core::{ Document, ContextBuilder };
 
     #[test]
     fn serialize_activity() {
         let activity = ActivityBuilder::default()
-            .with_base(|builder|
-                builder.object_type(Some("Activity".into()))
-                .summary(Some("Sally did something to a note".into()))
-            )
-            .with_object(|builder|
-                builder.object_type(Some("Note".into()))
-                .name(Some("A Note".into()))
-            )
-            .with_actor(|actor|
-                actor.with_base(|builder|
-                    builder.object_type(Some("Person".into()))
-                    .name(Some("Sally".into()))
-                )
-            )
-            .build().unwrap();
+            .with_base(|builder| {
+                builder
+                    .object_type(Some("Activity".into()))
+                    .summary(Some("Sally did something to a note".into()))
+            })
+            .with_object(|builder| {
+                builder
+                    .object_type(Some("Note".into()))
+                    .name(Some("A Note".into()))
+            })
+            .with_actor(|actor| {
+                actor.with_base(|builder| {
+                    builder
+                        .object_type(Some("Person".into()))
+                        .name(Some("Sally".into()))
+                })
+            })
+            .build()
+            .unwrap();
         let actual = Document::new(ContextBuilder::default().build().unwrap(), activity);
         let expected = String::from(
             r#"{

--- a/src/core/activity.rs
+++ b/src/core/activity.rs
@@ -88,6 +88,7 @@ mod tests {
     use super::*;
     use crate::core::{ContextBuilder, Document};
     use pretty_assertions::assert_eq;
+    use serde_json::json;
 
     #[test]
     fn serialize_activity() {
@@ -112,46 +113,42 @@ mod tests {
             .build()
             .unwrap();
         let actual = Document::new(ContextBuilder::default().build().unwrap(), activity);
-        let expected = String::from(
-            r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Activity",
-  "summary": "Sally did something to a note",
-  "actor": {
-    "type": "Person",
-    "name": "Sally"
-  },
-  "object": {
-    "type": "Note",
-    "name": "A Note"
-  }
-}"#,
-        );
-        assert!(actual.serialize_pretty().is_ok());
-        assert_eq!(actual.serialize_pretty().unwrap(), expected);
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Activity",
+          "summary": "Sally did something to a note",
+          "actor": {
+            "type": "Person",
+            "name": "Sally"
+          },
+          "object": {
+            "type": "Note",
+            "name": "A Note"
+          }
+        });
+        assert_eq!(serde_json::to_value(actual).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_activity() {
-        let actual = String::from(
-            r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Activity",
-  "summary": "Sally did something to a note",
-  "actor": {
-    "type": "Person",
-    "name": "Sally"
-  },
-  "object": {
-    "type": "Note",
-    "name": "A Note"
-  }
-}"#,
-        );
+        let actual = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Activity",
+          "summary": "Sally did something to a note",
+          "actor": {
+            "type": "Person",
+            "name": "Sally"
+          },
+          "object": {
+            "type": "Note",
+            "name": "A Note"
+          }
+        })
+        .to_string();
         let document: Document<Activity> = Document::deserialize_string(actual).unwrap();
         let activity = document.object as Activity;
         assert_eq!(activity.base.object_type, Some("Activity".into()));

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -1,6 +1,6 @@
-use serde::{ Deserialize, Serialize };
-use crate::core::object::{ Object, ObjectBuilder };
+use crate::core::object::{Object, ObjectBuilder};
 use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
 
 // TODO: expand to actor types: https://www.w3.org/TR/activitystreams-vocabulary/#actor-types
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Builder)]
@@ -30,9 +30,9 @@ pub struct Actor {
 }
 
 impl ActorBuilder {
-
     pub fn with_base<F>(&mut self, build_fn: F) -> &mut Self
-        where F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder
+    where
+        F: FnOnce(&mut ObjectBuilder) -> &mut ObjectBuilder,
     {
         let mut base_builder = ObjectBuilder::default();
         self.base(build_fn(&mut base_builder).build().unwrap())
@@ -51,19 +51,22 @@ pub struct PublicKeyInfo {
 mod tests {
     use super::*;
     use crate::core::{ContextBuilder, Document};
-    use pretty_assertions::assert_eq;
     use http::Uri;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn serialize_actor() {
         let person = ActorBuilder::default()
-            .with_base(|base|
+            .with_base(|base| {
                 base.object_type(Some("Person".into()))
-                .id(Some("https://example.com/person/1234".parse::<Uri>().unwrap()))
-                .name(Some("name".into()))
-            )
+                    .id(Some(
+                        "https://example.com/person/1234".parse::<Uri>().unwrap(),
+                    ))
+                    .name(Some("name".into()))
+            })
             .preferred_username(Some("dma".into()))
-            .build().unwrap();
+            .build()
+            .unwrap();
         let context = ContextBuilder::new().build().unwrap();
         let actual = Document::new(context, person);
         let expected = r#"{
@@ -94,7 +97,10 @@ mod tests {
         let document: Document<Actor> = Document::deserialize_string(actual.into()).unwrap();
         let actor = document.object;
         assert_eq!(actor.base.object_type, Some("Person".into()));
-        assert_eq!(actor.base.id, Some("https://example.com/person/1234".parse::<Uri>().unwrap()));
+        assert_eq!(
+            actor.base.id,
+            Some("https://example.com/person/1234".parse::<Uri>().unwrap())
+        );
         assert_eq!(actor.base.name, Some("name".into()));
         assert_eq!(actor.preferred_username, Some("dma".into()));
     }

--- a/src/core/actor.rs
+++ b/src/core/actor.rs
@@ -53,6 +53,7 @@ mod tests {
     use crate::core::{ContextBuilder, Document};
     use http::Uri;
     use pretty_assertions::assert_eq;
+    use serde_json::json;
 
     #[test]
     fn serialize_actor() {
@@ -69,32 +70,33 @@ mod tests {
             .unwrap();
         let context = ContextBuilder::new().build().unwrap();
         let actual = Document::new(context, person);
-        let expected = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Person",
-  "id": "https://example.com/person/1234",
-  "name": "name",
-  "preferredUsername": "dma"
-}"#;
-        let s = serde_json::to_string_pretty(&actual);
-        assert!(s.is_ok());
-        assert_eq!(s.unwrap(), expected)
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Person",
+          "id": "https://example.com/person/1234",
+          "name": "name",
+          "preferredUsername": "dma"
+        });
+
+        let v = serde_json::to_value(&actual);
+        assert_eq!(v.unwrap(), expected)
     }
 
     #[test]
     fn deserialize_actor() {
-        let actual = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Person",
-  "id": "https://example.com/person/1234",
-  "name": "name",
-  "preferredUsername": "dma"
-}"#;
-        let document: Document<Actor> = Document::deserialize_string(actual.into()).unwrap();
+        let actual = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Person",
+          "id": "https://example.com/person/1234",
+          "name": "name",
+          "preferredUsername": "dma"
+        })
+        .to_string();
+        let document: Document<Actor> = Document::deserialize_string(actual).unwrap();
         let actor = document.object;
         assert_eq!(actor.base.object_type, Some("Person".into()));
         assert_eq!(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -106,6 +106,8 @@ impl ContextBuilder {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -115,23 +117,22 @@ mod tests {
             .build()
             .unwrap();
 
-        let expected = r#"{
-  "@vocab": "https://www.w3.org/ns/activitystreams",
-  "@language": "en"
-}"#;
-        let serialize_pretty = serde_json::to_string_pretty(&ctx);
-        assert!(serialize_pretty.is_ok());
-        assert_eq!(serialize_pretty.ok().unwrap(), expected)
+        let expected = json!({
+          "@vocab": "https://www.w3.org/ns/activitystreams",
+          "@language": "en"
+        });
+        let value = serde_json::to_value(&ctx);
+        assert_eq!(value.unwrap(), expected)
     }
 
     #[test]
     fn deserialize_context() {
-        let actual = String::from(
-            r#"{
-    "@vocab": "https://www.w3.org/ns/activitystreams",
-    "@language": "en"
-}"#,
-        );
+        let actual = json!(
+                    {
+            "@vocab": "https://www.w3.org/ns/activitystreams",
+            "@language": "en"
+        })
+        .to_string();
         let ctx: Context = serde_json::from_str(&actual).unwrap();
         assert_eq!(ctx.language, Some("en".into()));
         assert_eq!(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,19 +1,19 @@
-pub mod object;
 pub mod activity;
 pub mod actor;
 pub mod collection;
+pub mod object;
 
 pub use object::*;
 
-use serde::{de::DeserializeOwned, Deserializer, Deserialize, Serialize};
 use derive_builder::Builder;
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 
 // TODO: rename to something else as there's a [Document] in the Activity
 // Streams spec.
 /// Outer object for serialization and deserialization. Not an Activity Streams
 /// 2.0 object.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
-pub struct Document<T> where {
+pub struct Document<T> {
     #[serde(rename = "@context", deserialize_with = "context_deserializer")]
     pub context: Context,
 
@@ -21,12 +21,12 @@ pub struct Document<T> where {
     pub object: T,
 }
 
-impl<T : DeserializeOwned + Serialize > Document<T> {
+impl<T: DeserializeOwned + Serialize> Document<T> {
     pub fn new(context: Context, object: T) -> Self {
         Document { context, object }
     }
 
-    pub fn serialize_pretty(&self) -> serde_json::Result<String>  {
+    pub fn serialize_pretty(&self) -> serde_json::Result<String> {
         let serialized = serde_json::to_string_pretty(&self);
         println!("serialized = {:?}", serialized);
         serialized
@@ -40,7 +40,7 @@ impl<T: DeserializeOwned + Serialize> Document<T> {
 }
 
 ///////////////////////////
-// Context 
+// Context
 ///////////////////////////
 /// JSON-LD uses the special @context property to define the processing context.
 /// The value of the @context property is defined by the [JSON-LD]
@@ -112,7 +112,8 @@ mod tests {
     fn serialize_context() {
         let ctx: Context = ContextBuilder::default()
             .language(Some("en".into()))
-            .build().unwrap();
+            .build()
+            .unwrap();
 
         let expected = r#"{
   "@vocab": "https://www.w3.org/ns/activitystreams",
@@ -125,14 +126,17 @@ mod tests {
 
     #[test]
     fn deserialize_context() {
-        let actual = String::from(r#"{
+        let actual = String::from(
+            r#"{
     "@vocab": "https://www.w3.org/ns/activitystreams",
     "@language": "en"
 }"#,
         );
         let ctx: Context = serde_json::from_str(&actual).unwrap();
         assert_eq!(ctx.language, Some("en".into()));
-        assert_eq!(ctx.namespace, "https://www.w3.org/ns/activitystreams".to_string());
-}
-
+        assert_eq!(
+            ctx.namespace,
+            "https://www.w3.org/ns/activitystreams".to_string()
+        );
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -52,7 +52,7 @@ impl<T: DeserializeOwned + Serialize> Document<T> {
 /// done using a string, object, or array.
 /// <https://www.w3.org/TR/activitystreams-core/#jsonld>
 
-const NAMESPACE: &'static str = "https://www.w3.org/ns/activitystreams";
+const NAMESPACE: &str = "https://www.w3.org/ns/activitystreams";
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 #[builder(default)]

--- a/src/core/object.rs
+++ b/src/core/object.rs
@@ -1,7 +1,7 @@
-use serde::{ Deserialize, Serialize };
-use chrono::{ DateTime, Utc };
+use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use http::Uri;
+use serde::{Deserialize, Serialize};
 
 ///////////////////////////
 // Object
@@ -42,7 +42,7 @@ pub struct Object {
     #[serde(
         rename = "attributedTo",
         skip_serializing_if = "Vec::is_empty",
-        default = "Vec::new",
+        default = "Vec::new"
     )]
     pub attributed_to: Vec<AttributedTo>,
 
@@ -78,10 +78,10 @@ pub struct Person(Object);
 pub struct Service(Object);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)] 
+#[serde(untagged)]
 pub enum AttributedTo {
     Object(Object),
-    Link(Link)
+    Link(Link),
 }
 
 impl ObjectBuilder {
@@ -90,14 +90,14 @@ impl ObjectBuilder {
     }
 
     pub fn of_object_type(t: String) -> Self {
-        ObjectBuilder::default()
-            .object_type(Some(t)).to_owned()
+        ObjectBuilder::default().object_type(Some(t)).to_owned()
     }
 
     pub fn note(name: String, content: String) -> Self {
         ObjectBuilder::of_object_type("Note".into())
-             .name(Some(name))
-             .content(Some(content)).to_owned()
+            .name(Some(name))
+            .content(Some(content))
+            .to_owned()
     }
 }
 
@@ -108,7 +108,7 @@ impl ObjectBuilder {
 // https://github.com/serde-rs/serde/issues/723#issuecomment-423299411
 mod opt_uri {
     use http::uri::Uri;
-    use serde::{Serialize, Serializer, Deserialize, Deserializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     pub fn serialize<S>(value: &Option<Uri>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -186,7 +186,7 @@ impl Link {
             hreflang: None,
             height: None,
             width: None,
-            preview: None
+            preview: None,
         }
     }
 }
@@ -228,26 +228,28 @@ impl Default for Preview {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{Context, ContextBuilder, Document, DocumentBuilder};
     use pretty_assertions::assert_eq;
     use serde_json::Result;
-    use crate::core::{ Context, ContextBuilder, Document, DocumentBuilder };
 
     #[test]
     fn serialize_object() {
         let object: Object = ObjectBuilder::default()
             .name(Some("name".into()))
-            .build().unwrap();
+            .build()
+            .unwrap();
         let context: Context = ContextBuilder::new()
             .language(Some("en".into()))
-            .build().unwrap();
+            .build()
+            .unwrap();
         let actual = DocumentBuilder::default()
             .object(Some(object))
             .context(context)
-            .build().unwrap();
+            .build()
+            .unwrap();
 
         let expected = r#"{
   "@context": {
@@ -294,18 +296,17 @@ mod tests {
 
     #[test]
     fn serialize_link() {
-        let href = Uri::from(
-            "http://example.org/abc".parse::<http::Uri>().unwrap(),
-        );
+        let href = Uri::from("http://example.org/abc".parse::<http::Uri>().unwrap());
         let actual = Document::new(
             ContextBuilder::new().build().unwrap(),
             LinkBuilder::new()
-            .href(href)
-            .name(Some("An example link".into()))
-            .hreflang(Some("en".into()))
-            .link_type(Some("Link".into()))
-            .media_type(Some("text/html".into()))
-            .build().unwrap(),
+                .href(href)
+                .name(Some("An example link".into()))
+                .hreflang(Some("en".into()))
+                .link_type(Some("Link".into()))
+                .media_type(Some("text/html".into()))
+                .build()
+                .unwrap(),
         );
         let expected = String::from(
             r#"{
@@ -317,7 +318,7 @@ mod tests {
   "mediaType": "text/html",
   "name": "An example link",
   "hreflang": "en"
-}"#
+}"#,
         );
         assert!(actual.serialize_pretty().is_ok());
         assert_eq!(actual.serialize_pretty().unwrap(), expected);
@@ -346,25 +347,24 @@ mod tests {
 
     #[test]
     fn serialize_preview() {
-         let trailer_preview = Link::new(
-            "http://example.org/trailer.mkv".into(),
-            "video/mkv".into()
-        );
+        let trailer_preview =
+            Link::new("http://example.org/trailer.mkv".into(), "video/mkv".into());
         let preview = PreviewBuilder::default()
             .duration(Some("PT1M".into()))
             .object_type(Some("Video".into()))
             .url(Some(Box::new(trailer_preview)))
             .name(Some("Trailer".into()))
-            .build().unwrap();
+            .build()
+            .unwrap();
 
         let object = ObjectBuilder::default()
             .duration(Some("PT2H30M".into()))
             .name(Some("Cool New Movie".into()))
             .preview(Some(Box::new(preview)))
             .object_type(Some("Video".into()))
-            .build().unwrap();
-        let context = ContextBuilder::new()
-            .build().unwrap();
+            .build()
+            .unwrap();
+        let context = ContextBuilder::new().build().unwrap();
         let actual = Document::new(context, object);
         let expected = String::from(
             r#"{
@@ -424,13 +424,20 @@ mod tests {
 
         let url = preview.url.as_ref().unwrap();
         assert_eq!(url.media_type, Some("video/mkv".into()));
-        assert_eq!(url.href, "http://example.org/trailer.mkv".parse::<http::Uri>().unwrap());
+        assert_eq!(
+            url.href,
+            "http://example.org/trailer.mkv"
+                .parse::<http::Uri>()
+                .unwrap()
+        );
     }
 
     #[test]
     fn serialize_note() {
         let context = ContextBuilder::new().build().unwrap();
-        let note = ObjectBuilder::note("Name".into(), "Content".into()).build().unwrap();
+        let note = ObjectBuilder::note("Name".into(), "Content".into())
+            .build()
+            .unwrap();
         let document: Document<Object> = Document::new(context, note);
         let expected = r#"{
   "@context": {
@@ -453,7 +460,8 @@ mod tests {
   "type": "Note",
   "name": "Name",
   "content": "Content"
-}"#.into();
+}"#
+        .into();
         let document: Document<Object> = Document::deserialize_string(actual).unwrap();
         let note: Object = document.object;
         assert_eq!(note.object_type, Some("Note".into()));

--- a/src/core/object.rs
+++ b/src/core/object.rs
@@ -293,7 +293,7 @@ mod tests {
 
     #[test]
     fn serialize_link() {
-        let href = Uri::from("http://example.org/abc".parse::<http::Uri>().unwrap());
+        let href = "http://example.org/abc".parse::<http::Uri>().unwrap();
         let actual = Document::new(
             ContextBuilder::new().build().unwrap(),
             LinkBuilder::new()

--- a/src/core/object.rs
+++ b/src/core/object.rs
@@ -233,7 +233,7 @@ mod tests {
     use super::*;
     use crate::core::{Context, ContextBuilder, Document, DocumentBuilder};
     use pretty_assertions::assert_eq;
-    use serde_json::Result;
+    use serde_json::{json, Result};
 
     #[test]
     fn serialize_object() {
@@ -251,29 +251,26 @@ mod tests {
             .build()
             .unwrap();
 
-        let expected = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams",
-    "@language": "en"
-  },
-  "name": "name"
-}"#;
-        let serialize_pretty = serde_json::to_string_pretty(&actual);
-        assert!(serialize_pretty.is_ok());
-        assert_eq!(serialize_pretty.ok().unwrap(), expected)
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams",
+            "@language": "en"
+          },
+          "name": "name"
+        });
+        assert_eq!(serde_json::to_value(&actual).unwrap(), expected)
     }
 
     #[test]
     fn deserialize_object() {
-        let actual = String::from(
-            r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams",
-    "@language": "en"
-  },
-  "name": "name"
-}"#,
-        );
+        let actual = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams",
+            "@language": "en"
+          },
+          "name": "name"
+        })
+        .to_string();
         let document: Document<Object> = Document::deserialize_string(actual).unwrap();
         assert_eq!(document.context.language, Some("en".into()));
         let object = document.object as Object;
@@ -284,11 +281,11 @@ mod tests {
     fn deserialize_object_malformed() {
         let actual = String::from(
             r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams",
-    "@language": "en"
-  },
-}"#,
+              "@context": {
+                "@vocab": "https://www.w3.org/ns/activitystreams",
+                "@language": "en"
+              },
+            }"#,
         );
         let result: Result<Document<Object>> = Document::deserialize_string(actual);
         assert!(result.is_err());
@@ -308,35 +305,31 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        let expected = String::from(
-            r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Link",
-  "href": "http://example.org/abc",
-  "mediaType": "text/html",
-  "name": "An example link",
-  "hreflang": "en"
-}"#,
-        );
-        assert!(actual.serialize_pretty().is_ok());
-        assert_eq!(actual.serialize_pretty().unwrap(), expected);
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Link",
+          "href": "http://example.org/abc",
+          "mediaType": "text/html",
+          "name": "An example link",
+          "hreflang": "en"
+        });
+        assert_eq!(serde_json::to_value(actual).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_link() {
-        let actual = String::from(
-            r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Link",
-  "href": "http://example.org/abc",
-  "name": "An example link",
-  "hreflang": "en"
-}"#,
-        );
+        let actual = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Link",
+          "href": "http://example.org/abc",
+          "name": "An example link",
+          "hreflang": "en"
+        })
+        .to_string();
         let document: Document<Link> = Document::deserialize_string(actual).unwrap();
         let link = document.object as Link;
         assert_eq!(link.link_type, Some("Link".into()));
@@ -366,51 +359,47 @@ mod tests {
             .unwrap();
         let context = ContextBuilder::new().build().unwrap();
         let actual = Document::new(context, object);
-        let expected = String::from(
-            r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Video",
-  "name": "Cool New Movie",
-  "duration": "PT2H30M",
-  "preview": {
-    "type": "Video",
-    "name": "Trailer",
-    "duration": "PT1M",
-    "url": {
-      "type": "Link",
-      "href": "http://example.org/trailer.mkv",
-      "mediaType": "video/mkv"
-    }
-  }
-}"#,
-        );
-        assert!(actual.serialize_pretty().is_ok());
-        assert_eq!(actual.serialize_pretty().unwrap(), expected);
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Video",
+          "name": "Cool New Movie",
+          "duration": "PT2H30M",
+          "preview": {
+            "type": "Video",
+            "name": "Trailer",
+            "duration": "PT1M",
+            "url": {
+              "type": "Link",
+              "href": "http://example.org/trailer.mkv",
+              "mediaType": "video/mkv"
+            }
+          }
+        });
+        assert_eq!(serde_json::to_value(actual).unwrap(), expected);
     }
 
     #[test]
     fn deserialize_preview() {
-        let actual = String::from(
-            r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Video",
-  "name": "Cool New Movie",
-  "duration": "PT2H30M",
-  "preview": {
-    "type": "Video",
-    "name": "Trailer",
-    "duration": "PT1M",
-    "url": {
-      "href": "http://example.org/trailer.mkv",
-      "mediaType": "video/mkv"
-    }
-  }
-}"#,
-        );
+        let actual = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Video",
+          "name": "Cool New Movie",
+          "duration": "PT2H30M",
+          "preview": {
+            "type": "Video",
+            "name": "Trailer",
+            "duration": "PT1M",
+            "url": {
+              "href": "http://example.org/trailer.mkv",
+              "mediaType": "video/mkv"
+            }
+          }
+        })
+        .to_string();
         let document: Document<Object> = Document::deserialize_string(actual).unwrap();
         let object = document.object;
         assert_eq!(object.object_type, Some("Video".into()));
@@ -439,29 +428,29 @@ mod tests {
             .build()
             .unwrap();
         let document: Document<Object> = Document::new(context, note);
-        let expected = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Note",
-  "name": "Name",
-  "content": "Content"
-}"#;
-        assert!(document.serialize_pretty().is_ok());
-        assert_eq!(document.serialize_pretty().unwrap(), expected)
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Note",
+          "name": "Name",
+          "content": "Content"
+        });
+
+        assert_eq!(serde_json::to_value(document).unwrap(), expected)
     }
 
     #[test]
     fn deserialize_note() {
-        let actual = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Note",
-  "name": "Name",
-  "content": "Content"
-}"#
-        .into();
+        let actual = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Note",
+          "name": "Name",
+          "content": "Content"
+        })
+        .to_string();
         let document: Document<Object> = Document::deserialize_string(actual).unwrap();
         let note: Object = document.object;
         assert_eq!(note.object_type, Some("Note".into()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,14 +399,12 @@ mod tests {
             })
             .with_actor(|actor| {
                 actor.with_base(|base_builder| {
-                    base_builder.object_type(Some("Person".into())).id(Some(
-                        "http://www.test.example/martin".parse::<Uri>().unwrap(),
-                    ))
+                    base_builder
+                        .object_type(Some("Person".into()))
+                        .id(Some("http://www.test.example/martin".parse().unwrap()))
                 })
             })
-            .with_object(|builder| {
-                builder.id(Some("http://example.org/foo.jpg".parse::<Uri>().unwrap()))
-            })
+            .with_object(|builder| builder.id(Some("http://example.org/foo.jpg".parse().unwrap())))
             .build()
             .unwrap();
         let actual = Document::new(ContextBuilder::new().build().unwrap(), activity);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,7 +434,10 @@ mod tests {
                 b.object_type(Some("Add".into()))
                     .summary(Some("Martin added an article to his blog".into()))
                     .published(Some(DateTime::<Utc>::from_utc(
-                        NaiveDate::from_ymd(2015, 2, 10).and_hms(15, 4, 55),
+                        NaiveDate::from_ymd_opt(2015, 2, 10)
+                            .unwrap()
+                            .and_hms_opt(15, 4, 55)
+                            .unwrap(),
                         Utc,
                     )))
             })
@@ -523,7 +526,10 @@ mod tests {
                 .object_type(Some("Note".into()))
                 .name(Some("My favourite stew recipe".into()))
                 .published(Some(DateTime::<Utc>::from_utc(
-                    NaiveDate::from_ymd(2014, 8, 21).and_hms(12, 34, 56),
+                    NaiveDate::from_ymd_opt(2014, 8, 21)
+                        .unwrap()
+                        .and_hms_opt(12, 34, 56)
+                        .unwrap(),
                     Utc,
                 )))
                 .attributed_to(vec![AttributedTo::Object(subject)])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod tests {
     use chrono::{DateTime, NaiveDate, Utc};
     use http::Uri;
     use pretty_assertions::assert_eq;
+    use serde_json::json;
 
     use crate::core::{
         activity::{Activity, ActivityBuilder},
@@ -19,13 +20,14 @@ mod tests {
     // A set of tests from https://www.w3.org/TR/activitystreams-vocabulary examples
     #[test]
     fn example_1() {
-        let listing = r#"{
+        let listing = json!({
           "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
           "type": "Object",
           "id": "http://www.test.example/object/1",
           "name": "A Simple, non-specific object"
-        }"#;
-        let object: Object = Document::deserialize_string(listing.into()).unwrap().object;
+        })
+        .to_string();
+        let object: Object = Document::deserialize_string(listing).unwrap().object;
         assert_eq!(object.object_type, Some("Object".into()));
         assert_eq!(
             object.id,
@@ -36,18 +38,17 @@ mod tests {
 
     #[test]
     fn example_2() {
-        let listing = r#"
-      {
-        "@context": {"@vocab": "https://www.w3.org/ns/activitystreams"},
-        "type": "Link",
-        "href": "http://example.org/abc",
-        "hreflang": "en",
-        "mediaType": "text/html",
-        "name": "An example link"
-      }
-      "#;
+        let listing = json!({
+          "@context": {"@vocab": "https://www.w3.org/ns/activitystreams"},
+          "type": "Link",
+          "href": "http://example.org/abc",
+          "hreflang": "en",
+          "mediaType": "text/html",
+          "name": "An example link"
+        })
+        .to_string();
 
-        let link: Link = Document::deserialize_string(listing.into()).unwrap().object;
+        let link: Link = Document::deserialize_string(listing).unwrap().object;
         assert_eq!(link.link_type, Some("Link".into()));
         assert_eq!(
             link.href,
@@ -60,23 +61,22 @@ mod tests {
 
     #[test]
     fn example_3() {
-        let listing = r#"
-      {
-        "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
-        "type": "Activity",
-        "summary": "Sally did something to a note",
-        "actor": {
-          "type": "Person",
-          "name": "Sally"
-        },
-        "object": {
-          "type": "Note",
-          "name": "A Note"
-        }
-      }
-      "#;
+        let listing = json!({
+          "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
+          "type": "Activity",
+          "summary": "Sally did something to a note",
+          "actor": {
+            "type": "Person",
+            "name": "Sally"
+          },
+          "object": {
+            "type": "Note",
+            "name": "A Note"
+          }
+        })
+        .to_string();
 
-        let activity: Activity = Document::deserialize_string(listing.into()).unwrap().object;
+        let activity: Activity = Document::deserialize_string(listing).unwrap().object;
         assert_eq!(activity.base.object_type, Some("Activity".into()));
         assert_eq!(
             activity.base.summary,
@@ -96,23 +96,22 @@ mod tests {
 
     #[test]
     fn example_4() {
-        let listing = r#"
-      {
-        "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
-        "type": "Travel",
-        "summary": "Sally went to work",
-        "actor": {
-          "type": "Person",
-          "name": "Sally"
-        },
-        "target": {
-          "type": "Place",
-          "name": "Work"
-        }
-      }
-      "#;
+        let listing = json!({
+          "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
+          "type": "Travel",
+          "summary": "Sally went to work",
+          "actor": {
+            "type": "Person",
+            "name": "Sally"
+          },
+          "target": {
+            "type": "Place",
+            "name": "Work"
+          }
+        })
+        .to_string();
 
-        let activity: Activity = Document::deserialize_string(listing.into()).unwrap().object;
+        let activity: Activity = Document::deserialize_string(listing).unwrap().object;
         assert_eq!(activity.base.object_type, Some("Travel".into()));
         assert_eq!(activity.base.summary, Some("Sally went to work".into()));
         assert!(activity.object.is_none());
@@ -130,8 +129,7 @@ mod tests {
 
     #[test]
     fn example_5() {
-        let listing = r#"
-        {
+        let listing = json!({
           "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
           "summary": "Sally's notes",
           "type": "Collection",
@@ -146,11 +144,10 @@ mod tests {
               "name": "Another Simple Note"
             }
           ]
-        }
-      "#;
+        })
+        .to_string();
 
-        let collection: Collection<Object> =
-            Document::deserialize_string(listing.into()).unwrap().object;
+        let collection: Collection<Object> = Document::deserialize_string(listing).unwrap().object;
         assert_eq!(collection.base.object_type, Some("Collection".into()));
         assert_eq!(collection.base.summary, Some("Sally's notes".into()));
         assert_eq!(collection.total_items, Some(2));
@@ -165,26 +162,26 @@ mod tests {
 
     #[test]
     fn example_6() {
-        let listing = r#"
-      {
-        "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
-        "summary": "Sally's notes",
-        "type": "OrderedCollection",
-        "totalItems": 2,
-        "orderedItems": [
-          {
-            "type": "Note",
-            "name": "A Simple Note"
-          },
-          {
-            "type": "Note",
-            "name": "Another Simple Note"
-          }
-        ]
-      }
-      "#;
+        let listing = json!({
+          "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
+          "summary": "Sally's notes",
+          "type": "OrderedCollection",
+          "totalItems": 2,
+          "orderedItems": [
+            {
+              "type": "Note",
+              "name": "A Simple Note"
+            },
+            {
+              "type": "Note",
+              "name": "Another Simple Note"
+            }
+          ]
+        })
+        .to_string();
+
         let collection: OrderedCollection<Object> =
-            Document::deserialize_string(listing.into()).unwrap().object;
+            Document::deserialize_string(listing).unwrap().object;
         assert_eq!(
             collection.base.object_type,
             Some("OrderedCollection".into())
@@ -202,27 +199,27 @@ mod tests {
 
     #[test]
     fn example_7() {
-        let listing = r#"
-      {
-        "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
-        "summary": "Page 1 of Sally's notes",
-        "type": "CollectionPage",
-        "id": "http://example.org/foo?page=1",
-        "partOf": "http://example.org/foo",
-        "items": [
-          {
-            "type": "Note",
-            "name": "A Simple Note"
-          },
-          {
-            "type": "Note",
-            "name": "Another Simple Note"
-          }
-        ]
-      }
-      "#;
+        let listing = json!({
+          "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
+          "summary": "Page 1 of Sally's notes",
+          "type": "CollectionPage",
+          "id": "http://example.org/foo?page=1",
+          "partOf": "http://example.org/foo",
+          "items": [
+            {
+              "type": "Note",
+              "name": "A Simple Note"
+            },
+            {
+              "type": "Note",
+              "name": "Another Simple Note"
+            }
+          ]
+        })
+        .to_string();
+
         let collection_page: CollectionPage<Object> =
-            Document::deserialize_string(listing.into()).unwrap().object;
+            Document::deserialize_string(listing).unwrap().object;
         assert_eq!(
             collection_page.base.base.object_type,
             Some("CollectionPage".into())
@@ -250,27 +247,27 @@ mod tests {
 
     #[test]
     fn example_8() {
-        let listing = r#"
-{
-  "@context": {"@vocab": "https://www.w3.org/ns/activitystreams"},
-  "summary": "Page 1 of Sally's notes",
-  "type": "OrderedCollectionPage",
-  "id": "http://example.org/foo?page=1",
-  "partOf": "http://example.org/foo",
-  "orderedItems": [
-    {
-      "type": "Note",
-      "name": "A Simple Note"
-    },
-    {
-      "type": "Note",
-      "name": "Another Simple Note"
-    }
-  ]
-}
-"#;
+        let listing = json!({
+          "@context": {"@vocab": "https://www.w3.org/ns/activitystreams"},
+          "summary": "Page 1 of Sally's notes",
+          "type": "OrderedCollectionPage",
+          "id": "http://example.org/foo?page=1",
+          "partOf": "http://example.org/foo",
+          "orderedItems": [
+            {
+              "type": "Note",
+              "name": "A Simple Note"
+            },
+            {
+              "type": "Note",
+              "name": "Another Simple Note"
+            }
+          ]
+        })
+        .to_string();
+
         let collection_page: OrderedCollectionPage<Object> =
-            Document::deserialize_string(listing.into()).unwrap().object;
+            Document::deserialize_string(listing).unwrap().object;
         assert_eq!(
             collection_page.base.base.object_type,
             Some("OrderedCollectionPage".into())
@@ -298,13 +295,15 @@ mod tests {
 
     #[test]
     fn example_53() {
-        let listing = r#"{
+        let listing = json!({
           "@context": { "@vocab": "https://www.w3.org/ns/activitystreams" },
           "type": "Note",
           "name": "A Word of Warning",
           "content": "Looks like it is going to rain today. Bring an umbrella!"
-        }"#;
-        let document: Document<Object> = Document::deserialize_string(listing.into()).unwrap();
+        })
+        .to_string();
+
+        let document: Document<Object> = Document::deserialize_string(listing).unwrap();
         let note = document.object;
         assert_eq!(note.object_type, Some("Note".into()));
         assert_eq!(note.name, Some("A Word of Warning".into()));
@@ -318,19 +317,21 @@ mod tests {
 
     #[test]
     fn example_69() {
-        let listing = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "name": "Holiday announcement",
-  "type": "Note",
-  "content": "Thursday will be a company-wide holiday. Enjoy your day off!",
-  "audience": {
-    "type": "http://example.org/Organization",
-    "name": "ExampleCo LLC"
-  }
-}"#;
-        let document: Document<Object> = Document::deserialize_string(listing.into()).unwrap();
+        let listing = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "name": "Holiday announcement",
+          "type": "Note",
+          "content": "Thursday will be a company-wide holiday. Enjoy your day off!",
+          "audience": {
+            "type": "http://example.org/Organization",
+            "name": "ExampleCo LLC"
+          }
+        })
+        .to_string();
+
+        let document: Document<Object> = Document::deserialize_string(listing).unwrap();
         let object = document.object;
         assert_eq!(object.name, Some("Holiday announcement".into()));
         assert_eq!(object.object_type, Some("Note".into()));
@@ -351,15 +352,17 @@ mod tests {
 
     #[test]
     fn example_114() {
-        let listing = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "summary": "A simple note",
-  "type": "Note",
-  "content": "A <em>simple</em> note"
-}"#;
-        let document: Document<Object> = Document::deserialize_string(listing.into()).unwrap();
+        let listing = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "summary": "A simple note",
+          "type": "Note",
+          "content": "A <em>simple</em> note"
+        })
+        .to_string();
+
+        let document: Document<Object> = Document::deserialize_string(listing).unwrap();
         let object = document.object;
         assert_eq!(object.summary, Some("A simple note".into()));
         assert_eq!(object.object_type, Some("Note".into()));
@@ -368,15 +371,17 @@ mod tests {
 
     #[test]
     fn example_133() {
-        let listing = r#"{
-        "@context": {
-          "@vocab": "https://www.w3.org/ns/activitystreams"
-        },
-        "name": "Cane Sugar Processing",
-        "type": "Note",
-        "summary": "A simple <em>note</em>"
-      }"#;
-        let document: Document<Object> = Document::deserialize_string(listing.into()).unwrap();
+        let listing = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "name": "Cane Sugar Processing",
+          "type": "Note",
+          "summary": "A simple <em>note</em>"
+        })
+        .to_string();
+
+        let document: Document<Object> = Document::deserialize_string(listing).unwrap();
         let object = document.object;
         assert_eq!(object.summary, Some("A simple <em>note</em>".into()));
         assert_eq!(object.object_type, Some("Note".into()));
@@ -405,22 +410,21 @@ mod tests {
             .build()
             .unwrap();
         let actual = Document::new(ContextBuilder::new().build().unwrap(), activity);
-        let expected = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Create",
-  "summary": "Martin created an image",
-  "actor": {
-    "type": "Person",
-    "id": "http://www.test.example/martin"
-  },
-  "object": {
-    "id": "http://example.org/foo.jpg"
-  }
-}"#;
-        assert!(actual.serialize_pretty().is_ok());
-        assert_eq!(actual.serialize_pretty().unwrap(), expected);
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Create",
+          "summary": "Martin created an image",
+          "actor": {
+            "type": "Person",
+            "id": "http://www.test.example/martin"
+          },
+          "object": {
+            "id": "http://example.org/foo.jpg"
+          }
+        });
+        assert_eq!(serde_json::to_value(actual).unwrap(), expected);
     }
 
     #[test]
@@ -471,38 +475,37 @@ mod tests {
             .unwrap();
 
         let actual = Document::new(ContextBuilder::new().build().unwrap(), activity);
-        let expected = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Add",
-  "published": "2015-02-10T15:04:55Z",
-  "summary": "Martin added an article to his blog",
-  "actor": {
-    "type": "Person",
-    "id": "http://www.test.example/martin",
-    "name": "Martin Smith",
-    "url": "http://example.org/martin",
-    "image": {
-      "type": "Link",
-      "href": "http://example.org/martin/image.jpg",
-      "mediaType": "image/jpeg"
-    }
-  },
-  "object": {
-    "type": "Article",
-    "id": "http://www.test.example/blog/abc123/xyz",
-    "name": "Why I love Activity Streams",
-    "url": "http://example.org/blog/2011/02/entry"
-  },
-  "target": {
-    "type": "OrderedCollection",
-    "id": "http://example.org/blog/",
-    "name": "Martin's Blog"
-  }
-}"#;
-        assert!(actual.serialize_pretty().is_ok());
-        assert_eq!(actual.serialize_pretty().unwrap(), expected);
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Add",
+          "published": "2015-02-10T15:04:55Z",
+          "summary": "Martin added an article to his blog",
+          "actor": {
+            "type": "Person",
+            "id": "http://www.test.example/martin",
+            "name": "Martin Smith",
+            "url": "http://example.org/martin",
+            "image": {
+              "type": "Link",
+              "href": "http://example.org/martin/image.jpg",
+              "mediaType": "image/jpeg"
+            }
+          },
+          "object": {
+            "type": "Article",
+            "id": "http://www.test.example/blog/abc123/xyz",
+            "name": "Why I love Activity Streams",
+            "url": "http://example.org/blog/2011/02/entry"
+          },
+          "target": {
+            "type": "OrderedCollection",
+            "id": "http://example.org/blog/",
+            "name": "Martin's Blog"
+          }
+        });
+        assert_eq!(serde_json::to_value(actual).unwrap(), expected);
     }
 
     #[test]
@@ -528,23 +531,22 @@ mod tests {
                 .unwrap(),
         );
 
-        let expected = r#"{
-  "@context": {
-    "@vocab": "https://www.w3.org/ns/activitystreams"
-  },
-  "type": "Note",
-  "id": "http://example.org/foo",
-  "name": "My favourite stew recipe",
-  "published": "2014-08-21T12:34:56Z",
-  "attributedTo": [
-    {
-      "type": "Person",
-      "id": "http://joe.website.example/",
-      "name": "Joe Smith"
-    }
-  ]
-}"#;
-        assert!(actual.serialize_pretty().is_ok());
-        assert_eq!(actual.serialize_pretty().unwrap(), expected);
+        let expected = json!({
+          "@context": {
+            "@vocab": "https://www.w3.org/ns/activitystreams"
+          },
+          "type": "Note",
+          "id": "http://example.org/foo",
+          "name": "My favourite stew recipe",
+          "published": "2014-08-21T12:34:56Z",
+          "attributedTo": [
+            {
+              "type": "Person",
+              "id": "http://joe.website.example/",
+              "name": "Joe Smith"
+            }
+          ]
+        });
+        assert_eq!(serde_json::to_value(actual).unwrap(), expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,19 @@
 pub mod core;
 
-extern crate serde;
 extern crate derive_builder;
-
+extern crate serde;
 
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, NaiveDate, Utc};
-    use pretty_assertions::assert_eq;
     use http::Uri;
+    use pretty_assertions::assert_eq;
 
     use crate::core::{
-        Document,
-        ContextBuilder,
-        collection::{ Collection, OrderedCollection, CollectionPage, OrderedCollectionPage },
-        activity::{ Activity, ActivityBuilder },
-        object::{ Object, ObjectBuilder, AttributedTo },
-        Link,
+        activity::{Activity, ActivityBuilder},
+        collection::{Collection, CollectionPage, OrderedCollection, OrderedCollectionPage},
+        object::{AttributedTo, Object, ObjectBuilder},
+        ContextBuilder, Document, Link,
     };
 
     // A set of tests from https://www.w3.org/TR/activitystreams-vocabulary examples
@@ -34,10 +31,7 @@ mod tests {
             object.id,
             Some("http://www.test.example/object/1".parse::<Uri>().unwrap())
         );
-        assert_eq!(
-            object.name,
-            Some("A Simple, non-specific object".into())
-        );
+        assert_eq!(object.name, Some("A Simple, non-specific object".into()));
     }
 
     #[test]
@@ -55,7 +49,10 @@ mod tests {
 
         let link: Link = Document::deserialize_string(listing.into()).unwrap().object;
         assert_eq!(link.link_type, Some("Link".into()));
-        assert_eq!(link.href, "http://example.org/abc".parse::<http::Uri>().unwrap());
+        assert_eq!(
+            link.href,
+            "http://example.org/abc".parse::<http::Uri>().unwrap()
+        );
         assert_eq!(link.hreflang, Some("en".into()));
         assert_eq!(link.media_type, Some("text/html".into()));
         assert_eq!(link.name, Some("An example link".into()));
@@ -76,12 +73,15 @@ mod tests {
           "type": "Note",
           "name": "A Note"
         }
-      } 
+      }
       "#;
 
         let activity: Activity = Document::deserialize_string(listing.into()).unwrap().object;
         assert_eq!(activity.base.object_type, Some("Activity".into()));
-        assert_eq!( activity.base.summary, Some("Sally did something to a note".into()));
+        assert_eq!(
+            activity.base.summary,
+            Some("Sally did something to a note".into())
+        );
 
         assert!(activity.actor.is_some());
         let actor = activity.actor.unwrap();
@@ -149,7 +149,8 @@ mod tests {
         }
       "#;
 
-        let collection: Collection<Object> = Document::deserialize_string(listing.into()).unwrap().object;
+        let collection: Collection<Object> =
+            Document::deserialize_string(listing.into()).unwrap().object;
         assert_eq!(collection.base.object_type, Some("Collection".into()));
         assert_eq!(collection.base.summary, Some("Sally's notes".into()));
         assert_eq!(collection.total_items, Some(2));
@@ -182,7 +183,8 @@ mod tests {
         ]
       }
       "#;
-        let collection: OrderedCollection<Object> = Document::deserialize_string(listing.into()).unwrap().object;
+        let collection: OrderedCollection<Object> =
+            Document::deserialize_string(listing.into()).unwrap().object;
         assert_eq!(
             collection.base.object_type,
             Some("OrderedCollection".into())
@@ -385,22 +387,24 @@ mod tests {
     #[test]
     fn minimal_activity_3_1() {
         let activity = ActivityBuilder::default()
-            .with_base(|builder|
-                  builder.object_type(Some("Create".into()))
-                  .summary(Some("Martin created an image".into()))
-            )
-            .with_actor(|actor|
-                actor.with_base(|base_builder|
-                    base_builder.object_type(Some("Person".into()))
-                    .id(Some("http://www.test.example/martin".parse::<Uri>().unwrap()))
-                )
-            )
-            .with_object(|builder| builder.id(Some("http://example.org/foo.jpg".parse::<Uri>().unwrap())))
-            .build().unwrap();
-        let actual = Document::new(
-            ContextBuilder::new().build().unwrap(),
-            activity
-        );
+            .with_base(|builder| {
+                builder
+                    .object_type(Some("Create".into()))
+                    .summary(Some("Martin created an image".into()))
+            })
+            .with_actor(|actor| {
+                actor.with_base(|base_builder| {
+                    base_builder.object_type(Some("Person".into())).id(Some(
+                        "http://www.test.example/martin".parse::<Uri>().unwrap(),
+                    ))
+                })
+            })
+            .with_object(|builder| {
+                builder.id(Some("http://example.org/foo.jpg".parse::<Uri>().unwrap()))
+            })
+            .build()
+            .unwrap();
+        let actual = Document::new(ContextBuilder::new().build().unwrap(), activity);
         let expected = r#"{
   "@context": {
     "@vocab": "https://www.w3.org/ns/activitystreams"
@@ -422,44 +426,51 @@ mod tests {
     #[test]
     fn basic_activity_with_additional_detail_3_2() {
         let activity = ActivityBuilder::default()
-            .with_base(|b|
+            .with_base(|b| {
                 b.object_type(Some("Add".into()))
-                .summary(Some("Martin added an article to his blog".into()))
-                .published(Some(DateTime::<Utc>::from_utc(
-                    NaiveDate::from_ymd(2015, 2, 10).and_hms(15, 4, 55),
-                    Utc,
-                )))
-            )
-            .with_actor(|actor|
-                actor.with_base(|base_builder|
-                    base_builder.object_type(Some("Person".into()))
-                    .id(Some("http://www.test.example/martin".parse::<Uri>().unwrap()))
-                    .name(Some("Martin Smith".into()))
-                    .image(Some(Link::new(
-                        "http://example.org/martin/image.jpg".into(),
-                        "image/jpeg".into(),
+                    .summary(Some("Martin added an article to his blog".into()))
+                    .published(Some(DateTime::<Utc>::from_utc(
+                        NaiveDate::from_ymd(2015, 2, 10).and_hms(15, 4, 55),
+                        Utc,
                     )))
-                    .url(Some("http://example.org/martin".into()))
-                )
-            )
+            })
+            .with_actor(|actor| {
+                actor.with_base(|base_builder| {
+                    base_builder
+                        .object_type(Some("Person".into()))
+                        .id(Some(
+                            "http://www.test.example/martin".parse::<Uri>().unwrap(),
+                        ))
+                        .name(Some("Martin Smith".into()))
+                        .image(Some(Link::new(
+                            "http://example.org/martin/image.jpg".into(),
+                            "image/jpeg".into(),
+                        )))
+                        .url(Some("http://example.org/martin".into()))
+                })
+            })
             // TODO: figure out how to get a 'Z' on this. probably requires a time-zone (so not naive)
-            .with_object(|builder|
-                 builder.object_type(Some("Article".into()))
-                 .id(Some("http://www.test.example/blog/abc123/xyz".parse::<Uri>().unwrap()))
-                 .name(Some("Why I love Activity Streams".into()))
-                 .url(Some("http://example.org/blog/2011/02/entry".into()))
-            )
-            .with_target(|target|
-                target.object_type(Some("OrderedCollection".into()))
-                .id(Some("http://example.org/blog/".parse::<Uri>().unwrap()))
-                .name(Some("Martin's Blog".into()))
-            )
-            .build().unwrap();
+            .with_object(|builder| {
+                builder
+                    .object_type(Some("Article".into()))
+                    .id(Some(
+                        "http://www.test.example/blog/abc123/xyz"
+                            .parse::<Uri>()
+                            .unwrap(),
+                    ))
+                    .name(Some("Why I love Activity Streams".into()))
+                    .url(Some("http://example.org/blog/2011/02/entry".into()))
+            })
+            .with_target(|target| {
+                target
+                    .object_type(Some("OrderedCollection".into()))
+                    .id(Some("http://example.org/blog/".parse::<Uri>().unwrap()))
+                    .name(Some("Martin's Blog".into()))
+            })
+            .build()
+            .unwrap();
 
-        let actual = Document::new(
-            ContextBuilder::new().build().unwrap(),
-            activity
-        );
+        let actual = Document::new(ContextBuilder::new().build().unwrap(), activity);
         let expected = r#"{
   "@context": {
     "@vocab": "https://www.w3.org/ns/activitystreams"
@@ -500,7 +511,8 @@ mod tests {
             .object_type(Some("Person".into()))
             .id(Some("http://joe.website.example/".parse::<Uri>().unwrap()))
             .name(Some("Joe Smith".into()))
-            .build().unwrap();
+            .build()
+            .unwrap();
         let actual = Document::new(
             ContextBuilder::new().build().unwrap(),
             ObjectBuilder::new()
@@ -512,7 +524,8 @@ mod tests {
                     Utc,
                 )))
                 .attributed_to(vec![AttributedTo::Object(subject)])
-                .build().unwrap()
+                .build()
+                .unwrap(),
         );
 
         let expected = r#"{


### PR DESCRIPTION
This is in response to [this comment](https://github.com/hachyserve/rustypub/pull/23/files#r1046103481). The main point is to use the `json!` macro instead of raw strings, see details in 357a96cd5a33239e98095c370eb20958b4f71059. 

I also on the side applied automated formatting and fixed a few clippy warnings, both because of my IDE configuration. I've done those in separate commits, so that they can be reviewed individually. But please note that I'm also happy to undo those changes, if you'd rather hand-format your code. Please just let me know!
